### PR TITLE
📝 [Update] Use dots to separating keys level when flattening JSON to a single level `generate locales`

### DIFF
--- a/lib/commands/impl/generate/locales/locales.dart
+++ b/lib/commands/impl/generate/locales/locales.dart
@@ -68,8 +68,9 @@ class GenerateLocalesCommand extends Command {
       });
     });
 
-    final parsedKeys =
-        keys.map((e) => '\tstatic const $e = \'$e\';').join('\n');
+    final parsedKeys = keys
+        .map((e) => '\tstatic const ${e.replaceAll(r'.', '_')} = \'$e\';')
+        .join('\n');
 
     final parsedLocales = StringBuffer('\n');
     final translationsKeys = StringBuffer();
@@ -106,11 +107,11 @@ class GenerateLocalesCommand extends Command {
       if (localization[key] is Map) {
         var nextAccKey = key;
         if (accKey != null) {
-          nextAccKey = '${accKey}_$key';
+          nextAccKey = '$accKey.$key';
         }
         _resolve(localization[key] as Map<String, dynamic>, result, nextAccKey);
       } else {
-        result[accKey != null ? '${accKey}_$key' : key] =
+        result[accKey != null ? '$accKey.$key' : key] =
             localization[key] as String?;
       }
     }


### PR DESCRIPTION
1. Use dots when flattening JSON to a single level and separating keys in `generate locales`
2. Support JSON key contain dots

This format makes it easier to represent nested structures in a flat key-value pair format.

#### For example

input:
`en_US.json`

```json
{
  "buttons": {
    "login": "Login",
    "sign_in": "Sign-in",
    "logout": "Logout",
    "sign_in_fb": "Sign-in with Facebook",
    "sign_in_google": "Sign-in with Google",
    "sign_in_apple": "Sign-in with Apple"
  }
}
```

output:

```dart
abstract class AppTranslation {

  static Map<String, Map<String, String>> translations = {
    'en_US' : Locales.en_US,
  };

}
abstract class LocaleKeys {
  static const buttons_login = 'buttons.login';
  static const buttons_sign_in = 'buttons.sign_in';
  static const buttons_logout = 'buttons.logout';
  static const buttons_sign_in_fb = 'buttons.sign_in_fb';
  static const buttons_sign_in_google = 'buttons.sign_in_google';
  static const buttons_sign_in_apple = 'buttons.sign_in_apple';
}

abstract class Locales {
  static const en_US = {
   'buttons.login': 'Login',
   'buttons.sign_in': 'Sign-in',
   'buttons.logout': 'Logout',
   'buttons.sign_in_fb': 'Sign-in with Facebook',
   'buttons.sign_in_google': 'Sign-in with Google',
   'buttons.sign_in_apple': 'Sign-in with Apple',
  };
}
```